### PR TITLE
Fix dependency issue with Vue Storybook

### DIFF
--- a/packages/vue-component-library/package.json
+++ b/packages/vue-component-library/package.json
@@ -80,6 +80,7 @@
     "sass-resources-loader": "^2.0.0",
     "uuid": "^3.3.2",
     "vue-jest": "^3.0.3",
+    "vue-loader": "^15.7.0",
     "vue-server-renderer": "^2.6.7",
     "vue-svg-inline-loader": "^1.2.11",
     "vue-svgicon": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14604,7 +14604,7 @@ vue-jest@^3.0.3:
     tsconfig "^7.0.0"
     vue-template-es2015-compiler "^1.6.0"
 
-vue-loader@^15.6.2:
+vue-loader@^15.6.2, vue-loader@^15.7.0:
   version "15.7.0"
   resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.7.0.tgz#27275aa5a3ef4958c5379c006dd1436ad04b25b3"
   integrity sha512-x+NZ4RIthQOxcFclEcs8sXGEWqnZHodL2J9Vq+hUz+TDZzBaDIh1j3d9M2IUlTjtrHTZy4uMuRdTi8BGws7jLA==


### PR DESCRIPTION
When starting storybook for the Vue components the user would get an error about a missing
dependency, 'vue-loader'. Added the dependency and that fixed the issue.
