### PR TITLE
added vue modal component and indicative css

### DIFF
--- a/packages/css-framework/src/components/_modal.scss
+++ b/packages/css-framework/src/components/_modal.scss
@@ -11,6 +11,10 @@
   padding: spacing(8);
   position: fixed;
 
+  &.open {
+    background-color: rgba(red, 0.3);
+  }
+
   .window {
     background-color: color(neutral, white);
     margin: auto;

--- a/packages/css-framework/src/components/_modal.scss
+++ b/packages/css-framework/src/components/_modal.scss
@@ -10,9 +10,13 @@
   display: flex;
   padding: spacing(8);
   position: fixed;
+  opacity:0;
+  pointer-events: none;
+
 
   &.open {
-    background-color: rgba(red, 0.3);
+    opacity: 100;
+    pointer-events: auto;
   }
 
   .window {

--- a/packages/vue-component-library/src/components/RnButton/__snapshots__/RnButton.spec.js.snap
+++ b/packages/vue-component-library/src/components/RnButton/__snapshots__/RnButton.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RnButton.vue snapshot: has same HTML structure 1`] = `
-<button class="rn-button + undefined"><span></span>
+<button class="rn-btn--primary "><span></span>
   <!----></button>
 `;

--- a/packages/vue-component-library/src/components/RnModal/RnModal.spec.js
+++ b/packages/vue-component-library/src/components/RnModal/RnModal.spec.js
@@ -8,7 +8,11 @@ describe('RnModal.vue', () => {
   beforeEach(() => {
     wrapper = shallow(RnModal, {
       propsData: {
-        //
+        title: 'This is a test title',
+        actionButtonText: 'ok',
+        hideCancel: false,
+        hideAction: false,
+        error: false
       },
     })
   })
@@ -24,4 +28,30 @@ describe('RnModal.vue', () => {
       expect(str).toMatchSnapshot()
     })
   })
+
+  it('Has expected props', () => {
+    const renderer = createRenderer()
+    expect(wrapper.props('title')).toBe('This is a test title')
+    expect(wrapper.props('actionButtonText')).toBe('ok')
+    expect(wrapper.props('hideCancel')).toBe(false)
+    expect(wrapper.props('hideAction')).toBe(false)
+    expect(wrapper.props('error')).toBe(false)
+  })
+
+  it('Displays a title', () => {
+    const renderer = createRenderer()
+    expect(wrapper.find('.title').text()).toBe('This is a test title')
+  })
+
+  it('Displays an action button', () => {
+    const renderer = createRenderer()
+    expect(wrapper.find('#action-button').text()).toBe('ok')
+  })
+
+  it('Displays a cancel button', () => {
+    const renderer = createRenderer()
+    expect(wrapper.find('#cancel-button').text()).toBe('Cancel')
+  })
+
+
 })

--- a/packages/vue-component-library/src/components/RnModal/RnModal.spec.js
+++ b/packages/vue-component-library/src/components/RnModal/RnModal.spec.js
@@ -30,7 +30,6 @@ describe('RnModal.vue', () => {
   })
 
   it('Has expected props', () => {
-    const renderer = createRenderer()
     expect(wrapper.props('title')).toBe('This is a test title')
     expect(wrapper.props('actionButtonText')).toBe('ok')
     expect(wrapper.props('hideCancel')).toBe(false)
@@ -39,17 +38,14 @@ describe('RnModal.vue', () => {
   })
 
   it('Displays a title', () => {
-    const renderer = createRenderer()
     expect(wrapper.find('.title').text()).toBe('This is a test title')
   })
 
   it('Displays an action button', () => {
-    const renderer = createRenderer()
     expect(wrapper.find('#action-button').text()).toBe('ok')
   })
 
   it('Displays a cancel button', () => {
-    const renderer = createRenderer()
     expect(wrapper.find('#cancel-button').text()).toBe('Cancel')
   })
 

--- a/packages/vue-component-library/src/components/RnModal/RnModal.stories.js
+++ b/packages/vue-component-library/src/components/RnModal/RnModal.stories.js
@@ -2,78 +2,93 @@ import { storiesOf } from '@storybook/vue'
 import { action } from '@storybook/addon-actions'
 
 import RnModal from './index.vue'
+import RnButton from '../RnButton/index.vue'
 
 storiesOf('Modals', module)
   .add('Basic', () => ({
-    components: { RnModal },
+    components: { RnModal, RnButton },
+    data() {
+      return {
+        isOpen: false
+      }
+    },
     template: `
+    <div>
+      <rn-button style="position:relative;z-index:9999" id="show-modal" state="neutral regular" @click="isOpen = true">Activate Modal</rn-button>
       <rn-modal
         title="Generic Card Content with a long title that wraps multiple rows"
         actionButtonText="I Understand"
-        v-on:cancel="cancel"
-        v-on:action="ok"
+        :class="{ open: isOpen }"
+        @close="isOpen = false"
+        @clickAction="isOpen = false"
       >
         <p>Sed posuere consectetur est at lobortis. Curabitur blandit tempus porttitor. Curabitur blandit tempus porttitor. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Donec sed odio dui.</p>
-      </rn-modal>`,
-    methods: {
-      cancel() {
-        action('cancel')
-      },
-      ok() {
-        action('ok')
-      },
-    },
+      </rn-modal>
+    </div>
+    `,
   }))
   .add('Hide action', () => ({
-    components: { RnModal },
+    components: { RnModal, RnButton },
+    data() {
+      return {
+        isOpen: false
+      }
+    },
     template: `
+    <div>
+      <rn-button style="position:relative;z-index:9999" id="show-modal" state="neutral regular" @click="isOpen = true">Activate Modal</rn-button>
       <rn-modal
         error
         hideAction
         title="Generic Card Content with a long title that wraps multiple rows"
-        v-on:cancel="cancel"
+        :class="{ open: isOpen }"
+        @close="isOpen = false"
       >
         <p>Sed posuere consectetur est at lobortis. Curabitur blandit tempus porttitor. Curabitur blandit tempus porttitor. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Donec sed odio dui.</p>
-      </rn-modal>`,
-    methods: {
-      cancel() {
-        action('cancel')
-      },
-    },
+      </rn-modal>
+    </div>
+      `,
   }))
   .add('Hide cancel', () => ({
-    components: { RnModal },
+    components: { RnModal, RnButton },
+    data() {
+      return {
+        isOpen: false
+      }
+    },
     template: `
+    <div>
+      <rn-button style="position:relative;z-index:9999" id="show-modal" state="neutral regular" @click="isOpen = true">Activate Modal</rn-button>
       <rn-modal
         error
         hideCancel
         title="Generic Card Content with a long title that wraps multiple rows"
-        v-on:cancel="cancel"
+        :class="{ open: isOpen }"
+        @clickAction="isOpen = false"
       >
         <p>Sed posuere consectetur est at lobortis. Curabitur blandit tempus porttitor. Curabitur blandit tempus porttitor. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Donec sed odio dui.</p>
-      </rn-modal>`,
-    methods: {
-      cancel() {
-        action('cancel')
-      },
-    },
+      </rn-modal>
+    </div>
+      `,
   }))
   .add('No Title', () => ({
-    components: { RnModal },
+    components: { RnModal, RnButton },
+    data() {
+      return {
+        isOpen: false
+      }
+    },
     template: `
+    <div>
+      <rn-button style="position:relative;z-index:9999" id="show-modal" state="neutral regular" @click="isOpen = true">Activate Modal</rn-button>
       <rn-modal
-        actionText="I Understand"
-        v-on:cancel="cancel"
-        v-on:action="ok"
+        actionButtonText="OK"
+        :class="{ open: isOpen }"
+        @close="isOpen = false"
+        @clickAction="isOpen = false"
       >
         <p>Sed posuere consectetur est at lobortis. Curabitur blandit tempus porttitor. Curabitur blandit tempus porttitor. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Donec sed odio dui.</p>
-      </rn-modal>`,
-    methods: {
-      cancel() {
-        action('cancel')
-      },
-      ok() {
-        action('ok')
-      },
-    },
+      </rn-modal>
+    </div>
+    `,
   }))

--- a/packages/vue-component-library/src/components/RnModal/RnModal.stories.js
+++ b/packages/vue-component-library/src/components/RnModal/RnModal.stories.js
@@ -92,3 +92,4 @@ storiesOf('Modals', module)
     </div>
     `,
   }))
+    

--- a/packages/vue-component-library/src/components/RnModal/__snapshots__/RnModal.spec.js.snap
+++ b/packages/vue-component-library/src/components/RnModal/__snapshots__/RnModal.spec.js.snap
@@ -3,11 +3,13 @@
 exports[`RnModal.vue snapshot: has same HTML structure 1`] = `
 <div class="rn-modal">
   <div class="window">
-    <!---->
+    <div class="header">
+      <h4 class="title">This is a test title</h4>
+    </div>
     <div class="content"></div>
     <div class="footer">
-      <rn-button-stub type="link" class="secondary h_mr-2">Cancel</rn-button-stub>
-      <rn-button-stub state="neutral regular">OK</rn-button-stub>
+      <rn-button-stub id="cancel-button" type="link" class="secondary h_mr-2">Cancel</rn-button-stub>
+      <rn-button-stub state="neutral regular" id="action-button">ok</rn-button-stub>
     </div>
   </div>
 </div>

--- a/packages/vue-component-library/src/components/RnModal/__snapshots__/RnModal.spec.js.snap
+++ b/packages/vue-component-library/src/components/RnModal/__snapshots__/RnModal.spec.js.snap
@@ -7,7 +7,7 @@ exports[`RnModal.vue snapshot: has same HTML structure 1`] = `
     <div class="content"></div>
     <div class="footer">
       <rn-button-stub type="link" class="secondary h_mr-2">Cancel</rn-button-stub>
-      <rn-button-stub>OK</rn-button-stub>
+      <rn-button-stub state="neutral regular">OK</rn-button-stub>
     </div>
   </div>
 </div>

--- a/packages/vue-component-library/src/components/RnModal/index.vue
+++ b/packages/vue-component-library/src/components/RnModal/index.vue
@@ -1,5 +1,5 @@
 <template lang="html">
-  <div class="rn-modal" v-bind:class="{ error: error }">
+  <div class="rn-modal" :class="{ error: error }">
     <div class="window">
       <div class="header" v-if="title">
         <h4 class="title">{{ title }}</h4>
@@ -9,11 +9,11 @@
       </div>
       <div class="footer">
         <template v-if="!hideCancel">
-          <rn-button class="secondary h_mr-2" type="link" @click="clickCancel">Cancel</rn-button>
+          <rn-button class="secondary h_mr-2" type="link" @click="$emit('close')">Cancel</rn-button>
         </template>
         <template v-if="!hideAction">
-          <rn-button v-if="error" type="error" @click="clickAction">{{ actionButtonText }}</rn-button>
-          <rn-button state="neutral regular" v-else @click="clickAction">{{ actionButtonText }}</rn-button>
+          <rn-button v-if="error" type="error" @click="$emit('clickAction')">{{ actionButtonText }}</rn-button>
+          <rn-button state="neutral regular" v-else @click="$emit('clickAction')">{{ actionButtonText }}</rn-button>
         </template>
       </div>
     </div>

--- a/packages/vue-component-library/src/components/RnModal/index.vue
+++ b/packages/vue-component-library/src/components/RnModal/index.vue
@@ -9,11 +9,11 @@
       </div>
       <div class="footer">
         <template v-if="!hideCancel">
-          <rn-button class="secondary h_mr-2" type="link" @click="$emit('close')">Cancel</rn-button>
+          <rn-button id="cancel-button" class="secondary h_mr-2" type="link" @click="$emit('close')">Cancel</rn-button>
         </template>
         <template v-if="!hideAction">
-          <rn-button v-if="error" type="error" @click="$emit('clickAction')">{{ actionButtonText }}</rn-button>
-          <rn-button state="neutral regular" v-else @click="$emit('clickAction')">{{ actionButtonText }}</rn-button>
+          <rn-button id="error-button" v-if="error" type="error" @click="$emit('clickAction')">{{ actionButtonText }}</rn-button>
+          <rn-button id="action-button" state="neutral regular" v-else @click="$emit('clickAction')">{{ actionButtonText }}</rn-button>
         </template>
       </div>
     </div>

--- a/packages/vue-component-library/src/components/RnModal/scripts.js
+++ b/packages/vue-component-library/src/components/RnModal/scripts.js
@@ -8,7 +8,7 @@ export default {
     RnButton,
   },
   data: () => ({
-    open: false,
+    isOpen: false,
   }),
   props: {
     title: String,
@@ -25,17 +25,5 @@ export default {
       default: 'OK',
     },
     error: Boolean,
-  },
-  methods: {
-    close() {
-      this.open = false
-      this.$emit('close')
-    },
-    clickCancel() {
-      this.$emit('cancel')
-    },
-    clickAction() {
-      this.$emit('action')
-    },
   },
 }


### PR DESCRIPTION
# Closes issue: EN-455

## Overview

Adds modal Vue component

## Work carried out

- [x] Added modal component
- [x] Added storybook stories
- [x] Added `open` class with sample css (just turns the modal on/off for now)

## Screenshot

![2019-04-01 16 00 10](https://user-images.githubusercontent.com/47984552/55337849-5555ec00-5497-11e9-83a0-83d48e91f9d5.gif)

## Developer Notes

@hxltrhuxze Some CSS work is needed on here to add the transitions as right now it just shows/hides. 
